### PR TITLE
build: remove jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ def computeVersionName() {
 
 buildscript {
     repositories {
+        mavenCentral()
         maven {
             url 'https://maven.google.com/'
             name 'Google'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,6 @@ def computeVersionName() {
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'

--- a/examples/example_react_native/android/build.gradle
+++ b/examples/example_react_native/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
@@ -21,7 +20,6 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"

--- a/examples/example_react_native/android/build.gradle
+++ b/examples/example_react_native/android/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     }
     repositories {
         google()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
@@ -20,6 +21,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
+        mavenCentral()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"


### PR DESCRIPTION
This is because of the removal/shutdown of jcenter on October 31, 2022.