### PR TITLE
Removed unused path require in CodeGenerator.web.js

### DIFF
--- a/src/CodeGenerator.web.js
+++ b/src/CodeGenerator.web.js
@@ -1,6 +1,6 @@
 import JsBarcode from 'jsbarcode';
 import QRCode from './qrcode';
-import { resolve } from 'path';
+
 const Type = {
   Code128: 'Code128',
   QRCode: 'QRCode'


### PR DESCRIPTION
This line was breaking my expo / react-native web builds in latest react-native-smart-code 1.1.0